### PR TITLE
Build _and_ Package in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-bin/
+build/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN apk add --update ca-certificates tzdata && \
+	rm -rf /var/cache/apk/*
+

--- a/build_in_docker.sh
+++ b/build_in_docker.sh
@@ -4,10 +4,24 @@
 # project, mounted inside a golang docker container.
 
 i=${1:-"quay.io/geonet/golang-godep"}
-p=${PWD/*\/gocode\/src\//} # I have my gocode in ~/gocode/src/...
+p=${PWD/${GOPATH}\/src\//}
 w="/go/src/${p}"
 
-#docker run --rm -e "GOBIN=${w}/bin" -e "CGO_ENABLED=0" -e "GOOS=linux" -v "/etc/passwd:/etc/passwd:ro" -u ${USER} -v $PWD:${w} -w ${w}/ -it $i godep go install -a -installsuffix cgo ./... 
+docker run --rm -e "GOBIN=${w}/build/bin" -e "CGO_ENABLED=0" -e "GOOS=linux" -v $PWD:${w} -w ${w}/ -it $i godep go install -a -installsuffix cgo ./...
 
-docker run --rm -e "GOBIN=${w}/bin" -e "CGO_ENABLED=0" -e "GOOS=linux" -v $PWD:${w} -w ${w}/ -it $i godep go install -a -installsuffix cgo ./... 
+docker build -t pagerduty-jobs:base - < Dockerfile.base
+
+# Docker images for apps
+cd build/bin
+for b in pd-*
+do
+	rm ../Dockerfile
+	echo "FROM pagerduty-jobs:base" > ../Dockerfile
+	echo "ADD bin/${b} /${b}" >> ../Dockerfile
+	echo "USER nobody" >> ../Dockerfile
+	echo "ENTRYPOINT [\"/${b}\"]" >> ../Dockerfile
+	docker build -t quay.io/geonet/pagerduty-jobs:$b ..
+done
+
+
 # vim: set ts=4 sw=4 tw=0 :

--- a/pd-find-user/pd-find-user.go
+++ b/pd-find-user/pd-find-user.go
@@ -4,14 +4,15 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 
 	"github.com/GeoNet/pagerduty-jobs/finduser"
 	"github.com/quiffman/go-pagerduty/pagerduty"
 )
 
 var (
-	subdomain string
-	apiKey    string
+	subdomain string = os.Getenv("PD_SUBDOMAIN")
+	apiKey    string = os.Getenv("PD_APIKEY")
 	user      string
 )
 

--- a/pd-list-incidents/pd-list-incidents.go
+++ b/pd-list-incidents/pd-list-incidents.go
@@ -9,14 +9,15 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/quiffman/go-pagerduty/pagerduty"
 )
 
 var (
-	subdomain string
-	apiKey    string
+	subdomain string = os.Getenv("PD_SUBDOMAIN")
+	apiKey    string = os.Getenv("PD_APIKEY")
 	filter    string
 )
 

--- a/pd-reassign-all/pd-reassign-all.go
+++ b/pd-reassign-all/pd-reassign-all.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"log"
+	"os"
 
 	"github.com/GeoNet/pagerduty-jobs/finduser"
 	"github.com/quiffman/go-pagerduty/pagerduty"
@@ -15,8 +16,8 @@ var (
 )
 
 var (
-	subdomain string
-	apiKey    string
+	subdomain string = os.Getenv("PD_SUBDOMAIN")
+	apiKey    string = os.Getenv("PD_APIKEY")
 	fromUser  string
 	toUser    string
 	toLevel   int = -1


### PR DESCRIPTION
This PR brings two changes.

Firstly, the default values for the pagerduty subdomain and api-key are read from environment variables.

Secondly, it adds packaging of the final docker images.
This is done, via an intermediate `Dockerfile.base`, from which each separate pagerduty-job binary is docker image is based.
This is based on the alpine linux docker image, which is around 5Mb, but includes busybox and package management - a great starting point for statically compiled golang binaries, with minimal external dependencies and where deployment doesn't require the tiniest possible image `FROM scratch`.
